### PR TITLE
Add readable name to A11y guideline groups

### DIFF
--- a/src/checks/pa11y/check.js
+++ b/src/checks/pa11y/check.js
@@ -27,7 +27,7 @@ exports.run = function run (siteName, siteType, url) {
     saveRawData(results, `${siteName}_${siteType}_pa11y`)
 
     const stats = statsFilter(results)
-    const topIssues = topIssuesPerGuidelineFilter(results, 3)
+    const topIssues = topIssuesPerGuidelineFilter(results, 5)
     const numberOfContrastErrors = numberOfSpecificIssueFilter(results, 'WCAG2AA.Principle1.Guideline1_4.1_4_3.G18.Fail')
 
     const metrics = {

--- a/src/checks/pa11y/filters/topIssuesPerGuideline.js
+++ b/src/checks/pa11y/filters/topIssuesPerGuideline.js
@@ -1,4 +1,3 @@
-
 /**
  * Get the top n guidelines with the most issues (warning, error or notice)
  * for the given pa11y results.
@@ -7,6 +6,37 @@
  * @param {number} count Maximum number of guidelines to return
  * @returns {Map} A sorted map of the top n issues
  */
+
+const GUIDELINES_TRANSLATION = {
+    'Guideline1_1': 'Guideline 1.1: Text Alternatives (Provide text alternatives for any non-text content so that it can be changed into other forms people need, such as large print, braille, speech, symbols or simpler language.)',
+    'Guideline1_2': 'Guideline 1.2: Time-based Media (Provide alternatives for time-based media.)',
+    'Guideline1_3': 'Guideline 1.3: Adaptable (Create content that can be presented in different ways (for example simpler layout) without losing information or structure.)',
+    'Guideline1_4': 'Guideline 1.4: Distinguishable (Make it easier for users to see and hear content including separating foreground from background. )',
+    'Guideline2_1': 'Guideline 2.1: Keyboard Accessible (Make all functionality available from a keyboard.)',
+    'Guideline2_2': 'Guideline 2.2: Enough Time (Provide users enough time to read and use content.)',
+    'Guideline2_3': 'Guideline 2.3: Seizures (Do not design content in a way that is known to cause seizures.)',
+    'Guideline2_4': 'Guideline 2.4: Navigable (Provide ways to help users navigate, find content, and determine where they are.)',
+    'Guideline3_1': 'Guideline 3.1: Readable (Make text content readable and understandable.)',
+    'Guideline3_2': 'Guideline 3.2: Predictable (Make Web pages appear and operate in predictable ways.)',
+    'Guideline3_3': 'Guideline 3.3: Input Assistance (Help users avoid and correct mistakes.)',
+    'Guideline4_1': 'Guideline 4.1: Compatible (Maximize compatibility with current and future user agents, including assistive technologies.)'
+}
+
+const GUIDELINES_TRANSLATION_SIMPLE = {
+    'Guideline1_1': 'Guideline1_1__Text_Alternatives',
+    'Guideline1_2': 'Guideline1_2__Time_based_Media',
+    'Guideline1_3': 'Guideline1_3__Adaptable',
+    'Guideline1_4': 'Guideline1_4__Distinguishable',
+    'Guideline2_1': 'Guideline2_1__Keyboard_Accessible',
+    'Guideline2_2': 'Guideline2_2__Enough_Time',
+    'Guideline2_3': 'Guideline2_3__Seizures',
+    'Guideline2_4': 'Guideline2_4__Navigable',
+    'Guideline3_1': 'Guideline3_1__Readable',
+    'Guideline3_2': 'Guideline3_2__Predictable',
+    'Guideline3_3': 'Guideline3_3__Input_Assistance',
+    'Guideline4_1': 'Guideline4_1__Compatible'
+}
+
 module.exports = (results, top) => {
   const guidelineMap = new Map()
 
@@ -16,8 +46,9 @@ module.exports = (results, top) => {
     // Result: [ 'WCAG2AA', 'Principle2', 'Guideline2_4', '2_4_1', 'H64', '1' ]
     const splittedCodes = issue.code.match(/([^.]+)/g)
     const guideline = splittedCodes[2]
+    const guidelineTranslation = GUIDELINES_TRANSLATION_SIMPLE[guideline] || guideline
 
-    guidelineMap.set(guideline, guidelineMap.get(guideline) + 1 || 1)
+    guidelineMap.set(guidelineTranslation, guidelineMap.get(guidelineTranslation) + 1 || 1)
   })
 
   const sortedGuidelines = [...guidelineMap.entries()].sort((a, b) => {


### PR DESCRIPTION
On the accessibility dashboard http://sitespeed.zeit.de/dashboard/db/accessibility-dashboard?refresh=5m&orgId=1 we only see the "cryptic" number of violated guidelines ("Guideline2_4").

This PR adds _some_ meaning to the strings, by providing the name of the guideline group ("Guideline2_4__Navigatable"). 

Source of this is https://squizlabs.github.io/HTML_CodeSniffer/Standards/WCAG2/ (you can grab the guidelines by `document.querySelectorAll('h4, h4+*').forEach(item => { console.log((item.getAttribute('id') || '') + item.textContent) })`. 

There is also a descriptional text ("Guideline 2.4: Navigable (Provide ways to help users navigate, find content, and determine where they are.)"), which I put in the code. But we cannot send this string as metric to Graphite. A solution might be to provide the whole senctence as undercore-seperated string.

Or maybe we dont want to list groups (2.4), but more specific violations ("SC 2.4.1: Bypass Blocks (Level A) A mechanism is available to bypass blocks of content that are repeated on multiple Web pages.") ? 

This PR can be a little improvement, and I am happy to discuss this further. **In the end, I want the dashboard to be actionable.** Maybe we can render the pa11y report as HTML, store it somewhere, and link to it from the dashboard?

## TODO

If this is fine, please build and deploy the master to k8s after merge.